### PR TITLE
Handle JSON serialization errors of log events

### DIFF
--- a/src/Serilog.Sinks.Logz.Io/Sinks/LogzIoSink.cs
+++ b/src/Serilog.Sinks.Logz.Io/Sinks/LogzIoSink.cs
@@ -37,11 +37,11 @@ public sealed class LogzIoSink : IBatchedLogEventSink
         if (_requestUrl == null || string.IsNullOrWhiteSpace(_requestUrl))
             return;
 
-        var payload = FormatPayload(batch);
-        var content = new StringContent(payload, Encoding.UTF8, "application/json");
-
         try
         {
+            var payload = FormatPayload(batch);
+            var content = new StringContent(payload, Encoding.UTF8, "application/json");
+
             var result = await _client
                 .PostAsync(_requestUrl, content)
                 .ConfigureAwait(false);


### PR DESCRIPTION
When logging events that include an exception that has a getter-property that throws an exception, it results in a JSON serialization exception that drops the entire log event instead of just the problematic property.

This was observed with Akka.NET when there was a problem with instantiating a new actor due to missing dependency injection configuration.

```
2023-03-14T07:04:49.5779163Z Exception while emitting periodic batch from Serilog.Sinks.Logz.Io.LogzioSink: Newtonsoft.Json.JsonSerializationException: Error gett
ing value from 'Dispatcher' on 'Akka.Actor.DeadLetterMailbox'.
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Akka.Dispatch.Mailbox.get_Dispatcher()
   at lambda_method357(Closure , Object )
   at Newtonsoft.Json.Serialization.ExpressionValueProvider.GetValue(Object target)
...
   at Serilog.Sinks.Logz.Io.LogzIoSerializer.Serialize[T](T value)
   at Serilog.Sinks.Logz.Io.LogzioSink.FormatLogEvent(LogEvent loggingEvent)
   at System.Linq.Enumerable.SelectEnumerableIterator`2.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at Serilog.Sinks.Logz.Io.LogzioSink.FormatPayload(IEnumerable`1 events)
   at Serilog.Sinks.Logz.Io.LogzioSink.EmitBatchAsync(IEnumerable`1 events)
   at Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink.OnTick()
```

By handling JSON errors, we can omit the problematic property instead of dropping the entire log event.
https://www.newtonsoft.com/json/help/html/serializationerrorhandling.htm

### Changes
- Handle JSON serialization errors to only lose problematic properties instead of the whole event
- Move `FormatPayload` into try-catch to handle any other exceptions during formatting

### Testing
- Add unit test case that failed before this fix
- The observed case with Akka.NET no longer drops the log event